### PR TITLE
Set action name for AppSignal

### DIFF
--- a/controllers/hello_controller.rb
+++ b/controllers/hello_controller.rb
@@ -2,7 +2,7 @@ require_relative 'base_controller'
 
 class HelloController < BaseController
   def hello
-    Appsignal.send_error(RuntimeError.new("foo"))
+    Appsignal.set_action("HelloController#hello")
     sleep 3
     { message: "Hello, World!" }
   end


### PR DESCRIPTION
If the action name is missing, the performance samples won't be reported to AppSignal.